### PR TITLE
Feature/comparacion pdfs para verificacion

### DIFF
--- a/controllers/controllerFirma.py
+++ b/controllers/controllerFirma.py
@@ -175,6 +175,19 @@ def postVerify(data):
                 resString = resString.replace("'","")
                 resString = resString.lstrip("b")
                 responseNuxeo = json.loads(resString)
+                #INICIO COMPARACIÓN
+                base64Nuxeo = str(responseNuxeo['file'])
+                base64User = str (data[i]["fileUp"])
+                urlFileUp = str (data[0]["urlFileUp"])
+                fileEqual = True #Por defecto true ya que de ser así sólo se muestra un Doc
+                if base64User != "":
+                    if base64Nuxeo == base64User:
+                        fileEqual = True
+                    else:
+                        fileEqual = False
+                #FIN COMPARACIÓN
+                responseNuxeo['fileEqual'] = fileEqual
+                responseNuxeo['urlFileUp'] = urlFileUp
                 response_array.append(responseNuxeo)
             else:
                 error_dict = {'Message': "electronic signatures do not match", 'code': '404'}

--- a/models/model_params.py
+++ b/models/model_params.py
@@ -37,6 +37,8 @@ def define_parameters(api):
 
     firma_model = [api.model('firma_request',{
         'firma': fields.String,
+        'fileUp': fields.String,
+        'urlFileUp': fields.String,
     })]
     
     return {k: v for k, v in vars().items() if not k.startswith('__')}


### PR DESCRIPTION
Se realiza la lógica correspondiente a la comparación de los base 64. Se cambió la respuesta enviada al cliente de verificación para que pudiese mostrar diferentes componentes html dependiendo de la respuesta. Esto corresponde al issue udistrital/core_documentacion#58